### PR TITLE
Clearer list of additional incl criteria in Protocol

### DIFF
--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -49,20 +49,11 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   markdown <- sub("### Inclusion Criteria", "### Additional Inclusion Criteria\n", markdown)
 
   markdown <- unnumberAdditionalCriteria(markdown)
-  as.roman <- function(digit_str) {
-    second_digit <- stopIfAboveForty(digit_str)
-    first_digit <- as.integer(stringr::str_sub(digit_str, start = -1))
-    romanized_str <- paste0(
-      paste(rep("X", second_digit), collapse = ''),
-      c("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX")[first_digit]
-    )
-    return(romanized_str)
-  }
   markdown <- stringr::str_replace_all(
     markdown, "#### (\\d+).",
     function(matched_str) {
       digit <- stringr::str_extract(matched_str, stringr::regex("\\d+"))
-      paste0("#### ", as.roman(digit), ".")
+      paste0("#### ", LegendT2dm:::as.roman(digit), ".")
     }
   )
 
@@ -91,6 +82,17 @@ unnumberAdditionalCriteria <- function(markdown) {
   return(markdown)
 }
 
+#' Convert a string of an integer < 40 to a string of a corresponding roman numeral.
+as.roman <- function(digit_str) {
+  second_digit <- stopIfAboveForty(digit_str)
+  first_digit <- as.integer(stringr::str_sub(digit_str, start = -1))
+  romanized_str <- paste0(
+    paste(rep("X", second_digit), collapse = ''),
+    c("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX")[first_digit]
+  )
+  return(romanized_str)
+}
+
 #' Does the given string of digit(s) indicate value larger than 40.
 #'
 #' @description
@@ -111,7 +113,6 @@ stopIfAboveForty <- function(digit_str) {
   }
   return(second_digit)
 }
-
 
 #' Print concept set
 #'

--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -46,8 +46,20 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   markdown <- gsub("The person exits the cohort", "\\\r\\\nThe person also exists the cohort", markdown)
   markdown <- gsub("following events:", "following events:\\\r\\\n", markdown)
 
-  markdown <- sub("### Inclusion Criteria", "### Additional Inclusion Criteria", markdown)
-  markdown <- gsub("#### \\d+.", "*", markdown)
+  markdown <- sub("### Inclusion Criteria", "### Additional Inclusion Criteria\n", markdown)
+
+  convert_to_roman_num <- function(digit_str) {
+    stopifnot(length(digit_str) == 1)
+    romanized <- c("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX")[as.integer(digit_str)]
+    return(romanized)
+  }
+  markdown <- stringr::str_replace_all(
+    markdown, "#### (\\d+).",
+    function(matched_str) {
+      digit <- stringr::str_extract(matched_str, stringr::regex("\\d+"))
+      paste0("#### ", convert_to_roman_num(digit), ".")
+    }
+  )
 
   rows <- unlist(strsplit(markdown, "\\r\\n"))
   rows <- gsub("^   ", "", rows)

--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -74,6 +74,7 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   }
 }
 
+#' Find the subsections corresponding to additional criteria and unnumber them.
 unnumberAdditionalCriteria <- function(markdown) {
   markdown <- stringr::str_replace_all(
     markdown, "#### (\\d+).(.*)",
@@ -93,7 +94,7 @@ as.roman <- function(digit_str) {
   return(romanized_str)
 }
 
-#' Does the given string of digit(s) indicate value larger than 40.
+#' Does the given string of digit(s) indicate value larger than 40?
 #'
 #' @description
 #' Check if string of digit(s) indicate value larger than 40. If not,

--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -49,7 +49,7 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   markdown <- sub("### Inclusion Criteria", "### Additional Inclusion Criteria\n", markdown)
 
   markdown <- unnumberAdditionalCriteria(markdown)
-  convert_to_roman_num <- function(digit_str) {
+  as.roman <- function(digit_str) {
     second_digit <- stopIfAboveForty(digit_str)
     first_digit <- as.integer(stringr::str_sub(digit_str, start = -1))
     romanized_str <- paste0(
@@ -62,7 +62,7 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
     markdown, "#### (\\d+).",
     function(matched_str) {
       digit <- stringr::str_extract(matched_str, stringr::regex("\\d+"))
-      paste0("#### ", convert_to_roman_num(digit), ".")
+      paste0("#### ", as.roman(digit), ".")
     }
   )
 

--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -53,7 +53,7 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
     markdown, "#### (\\d+).",
     function(matched_str) {
       digit <- stringr::str_extract(matched_str, stringr::regex("\\d+"))
-      paste0("#### ", LegendT2dm:::as.roman(digit), ".")
+      paste0("#### ", utils::as.roman(digit), ".")
     }
   )
 
@@ -81,38 +81,6 @@ unnumberAdditionalCriteria <- function(markdown) {
     function(matched_str) { paste(matched_str, "{-}") }
   )
   return(markdown)
-}
-
-#' Convert a string of an integer < 40 to a string of a corresponding roman numeral.
-as.roman <- function(digit_str) {
-  second_digit <- stopIfAboveForty(digit_str)
-  first_digit <- as.integer(stringr::str_sub(digit_str, start = -1))
-  romanized_str <- paste0(
-    paste(rep("X", second_digit), collapse = ''),
-    c("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX")[first_digit]
-  )
-  return(romanized_str)
-}
-
-#' Does the given string of digit(s) indicate value larger than 40?
-#'
-#' @description
-#' Check if string of digit(s) indicate value larger than 40. If not,
-#' return the second digit. If single digit, returns 0.
-stopIfAboveForty <- function(digit_str) {
-  num_digits <- nchar(digit_str)
-  if (num_digits >= 2) {
-    second_digit_and_above <- as.integer(substr(digit_str, 1, num_digits - 1))
-    if (second_digit_and_above >= 4) {
-      stop(paste("Additional cohort inclusion criteria numbered >= 40 detected.",
-                 "The current cohort definition formatter does not support this."))
-    } else {
-      second_digit <- second_digit_and_above
-    }
-  } else {
-    second_digit <- 0
-  }
-  return(second_digit)
 }
 
 #' Print concept set

--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -49,9 +49,13 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   markdown <- sub("### Inclusion Criteria", "### Additional Inclusion Criteria\n", markdown)
 
   convert_to_roman_num <- function(digit_str) {
-    stopifnot(length(digit_str) == 1)
-    romanized <- c("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX")[as.integer(digit_str)]
-    return(romanized)
+    second_digit <- stopIfAboveForty(digit_str)
+    first_digit <- as.integer(stringr::str_sub(digit_str, start = -1))
+    romanized_str <- paste0(
+      paste(rep("X", second_digit), collapse = ''),
+      c("I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX")[first_digit]
+    )
+    return(romanized_str)
   }
   markdown <- stringr::str_replace_all(
     markdown, "#### (\\d+).",
@@ -76,6 +80,27 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   if (withClosing) {
     printCohortClose()
   }
+}
+
+#' Does the given string of digit(s) indicate value larger than 40.
+#'
+#' @description
+#' Check if string of digit(s) indicate value larger than 40. If not,
+#' return the second digit. If single digit, returns 0.
+stopIfAboveForty <- function(digit_str) {
+  num_digits <- nchar(digit_str)
+  if (num_digits >= 2) {
+    second_digit_and_above <- as.integer(substr(digit_str, 1, num_digits - 1))
+    if (second_digit_and_above >= 4) {
+      stop(paste("Additional cohort inclusion criteria numbered >= 40 detected.",
+                 "The current cohort definition formatter does not support this."))
+    } else {
+      second_digit <- second_digit_and_above
+    }
+  } else {
+    second_digit <- 0
+  }
+  return(second_digit)
 }
 
 

--- a/R/PrettyOutput.R
+++ b/R/PrettyOutput.R
@@ -48,6 +48,7 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
 
   markdown <- sub("### Inclusion Criteria", "### Additional Inclusion Criteria\n", markdown)
 
+  markdown <- unnumberAdditionalCriteria(markdown)
   convert_to_roman_num <- function(digit_str) {
     second_digit <- stopIfAboveForty(digit_str)
     first_digit <- as.integer(stringr::str_sub(digit_str, start = -1))
@@ -80,6 +81,14 @@ printCohortDefinitionFromNameAndJson <- function(name, json = NULL, obj = NULL,
   if (withClosing) {
     printCohortClose()
   }
+}
+
+unnumberAdditionalCriteria <- function(markdown) {
+  markdown <- stringr::str_replace_all(
+    markdown, "#### (\\d+).(.*)",
+    function(matched_str) { paste(matched_str, "{-}") }
+  )
+  return(markdown)
 }
 
 #' Does the given string of digit(s) indicate value larger than 40.


### PR DESCRIPTION
The current formatting makes the list of additional cohort inclusion criteria confusing. Here is one possibility to make is a bit more readable. Before and after my change shown below:

**Current list formatting:**
<img width="939" alt="Screen Shot 2022-04-16 at 10 08 08 AM" src="https://user-images.githubusercontent.com/12732968/163656145-34707ed9-0e57-40f9-8f82-41976068d092.png">

**Updated list formatting:**
<img width="945" alt="Screen Shot 2022-04-16 at 10 07 28 AM" src="https://user-images.githubusercontent.com/12732968/163656149-35dd226f-fe11-491a-a43b-8a5db150a504.png">

Let me know @msuchard if you think this is a worthy change; if so, I have to polish the code a bit more for it to work when there are more than 10 additional inclusion criteria. 
 